### PR TITLE
TCP Fin Detection

### DIFF
--- a/src/Socket/ClientSocket/TimingSocket/KernelTimingSocket/KernelTimingSocket.cpp
+++ b/src/Socket/ClientSocket/TimingSocket/KernelTimingSocket/KernelTimingSocket.cpp
@@ -164,6 +164,10 @@ ssize_t Socket::KernelTimingSocket::read(void *buf, size_t size, bool blocking) 
         flags = flags | MSG_DONTWAIT;
     }
     rc = recvmsg(sock, &msg, flags);
+    if(rc == 0) {
+        // peer closed
+        return rc;
+    }
     if (rc < 0) {
         switch (errno) {
             case EAGAIN:

--- a/src/Socket/ClientSocket/TimingSocket/TimingSocket.cpp
+++ b/src/Socket/ClientSocket/TimingSocket/TimingSocket.cpp
@@ -49,25 +49,23 @@ void Socket::TimingSocket::connect(std::string host, uint16_t port) {
         }
         int attempts = 0;
         while(sock < 0 && attempts < 100) {
-			std::cout << "Failed to reach host. Will sleep and try again.\n" << std::endl;
-			std::this_thread::sleep_for(std::chrono::milliseconds(5));
-			sock = socket(res->ai_family, res->ai_socktype,
+            std::cout << "Failed to reach host. Will sleep and try again.\n" << std::endl;
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            sock = socket(res->ai_family, res->ai_socktype,
                    res->ai_protocol);
-			if (::connect(sock, res->ai_addr, res->ai_addrlen) < 0) {
-				::close(sock);
-				sock = -1;
-			} else {
-				std::cout << "Managed to connect in new attempt.\n" << std::endl;
-			}
-			attempts +=1;
-		}
-		if(sock < 0) {
-			continue;
-		}
+            if (::connect(sock, res->ai_addr, res->ai_addrlen) < 0) {
+                ::close(sock);
+                sock = -1;
+            }
+            attempts++;
+        }
+        if(sock < 0) {
+            continue;
+        }
         /* socket opened */
         state = SOCKSTATE_ESTABLISHED;
         break;
-}
+    }
     if (sock < 0) {
         throw std::runtime_error(std::string("Unable to open socket for host \""+host+":"+std::to_string(port)+"\""));
     }

--- a/src/Socket/ClientSocket/TimingSocket/TimingSocket.cpp
+++ b/src/Socket/ClientSocket/TimingSocket/TimingSocket.cpp
@@ -9,6 +9,8 @@
 #include <cstring>
 #include <stdexcept>
 #include <iostream>
+#include <chrono>
+#include <thread>
 #include "CPUTimingSocket/CPUTimingSocket.h"
 #include "KernelTimingSocket/KernelTimingSocket.h"
 #include "PCAPTimingSocket/PCAPTimingSocket.h"
@@ -44,12 +46,28 @@ void Socket::TimingSocket::connect(std::string host, uint16_t port) {
         if (::connect(sock, res->ai_addr, res->ai_addrlen) < 0) {
             ::close(sock);
             sock = -1;
-            continue;
         }
+        int attempts = 0;
+        while(sock < 0 && attempts < 100) {
+			std::cout << "Failed to reach host. Will sleep and try again.\n" << std::endl;
+			std::this_thread::sleep_for(std::chrono::milliseconds(5));
+			sock = socket(res->ai_family, res->ai_socktype,
+                   res->ai_protocol);
+			if (::connect(sock, res->ai_addr, res->ai_addrlen) < 0) {
+				::close(sock);
+				sock = -1;
+			} else {
+				std::cout << "Managed to connect in new attempt.\n" << std::endl;
+			}
+			attempts +=1;
+		}
+		if(sock < 0) {
+			continue;
+		}
         /* socket opened */
         state = SOCKSTATE_ESTABLISHED;
         break;
-    }
+}
     if (sock < 0) {
         throw std::runtime_error(std::string("Unable to open socket for host \""+host+":"+std::to_string(port)+"\""));
     }


### PR DESCRIPTION
According to our tests, the proxy always expected a TCP response with payload and did not detect a TCP FIN as a reaction of the tested peer. This PR aims to address this.